### PR TITLE
Bunch of stuff

### DIFF
--- a/wren-mode.el
+++ b/wren-mode.el
@@ -171,8 +171,8 @@
   "Major mode for editing Wren."
 
   ;; syntax table
-  (modify-syntax-entry ?/ ". 124b" wren-mode-syntax-table)
-  (modify-syntax-entry ?* ". 23" wren-mode-syntax-table)
+  (modify-syntax-entry ?/ ". 124bn" wren-mode-syntax-table)
+  (modify-syntax-entry ?* ". 23bn" wren-mode-syntax-table)
   (modify-syntax-entry ?\n "> b" wren-mode-syntax-table)
   (modify-syntax-entry ?+ "." wren-mode-syntax-table)
   (modify-syntax-entry ?^ "." wren-mode-syntax-table)

--- a/wren-mode.el
+++ b/wren-mode.el
@@ -181,6 +181,10 @@
   (modify-syntax-entry ?~ "." wren-mode-syntax-table)
   (modify-syntax-entry ?_ "_" wren-mode-syntax-table)
 
+  ;; abbrev table
+  ;; See: https://groups.google.com/forum/#!topic/wren-lang/T3uZmpZT6PA
+  (define-abbrev wren-mode-abbrev-table "Sys" "System" nil :case-fixed)
+
   (setq font-lock-defaults '((wren-font-lock-keywords)))
 
   (set (make-local-variable 'electric-indent-chars) '(?\n ?\}))

--- a/wren-mode.el
+++ b/wren-mode.el
@@ -40,17 +40,17 @@
 ;;; Code:
 
 
-(defconst wren-keywords:data
-  '("class" "var" "new")
-  "Wren keywords for data.")
+(defconst wren-keywords
+  '("break" "class" "construct" "else" "for"
+    "foreign" "if" "import" "in" "is"
+    "return" "static" "super" "this" "var"
+    "while")
+  "Wren language keywords.")
 
-(defconst wren-keywords:control-flow
-  '("if" "else" "while" "for" "return")
-  "Wren keywords for control flow.")
+(defconst wren-constants
+  '("true" "false" "null")
+  "Wren language constants.")
 
-(defconst wren-keywords:op:logic
-  '("and" "or" "not" "is")
-  "Wren keywords for control flow.")
 
 (defcustom wren-tab-width tab-width
   "The tab width to use when indenting."
@@ -67,12 +67,10 @@
   (let ((beg "\\<")
         (end "\\>"))
     (list
-     (cons (concat beg (regexp-opt wren-keywords:data t) end)
+     (cons (concat beg (regexp-opt wren-keywords t) end)
            font-lock-keyword-face)
-     (cons (concat beg (regexp-opt wren-keywords:control-flow t) end)
-           font-lock-keyword-face)
-     (cons (concat beg (regexp-opt wren-keywords:op:logic t) end)
-           font-lock-keyword-face)
+     (cons (concat beg (regexp-opt wren-constants t) end)
+           font-lock-constant-face)
      (cons wren-this-regexp font-lock-variable-name-face)
      (cons wren-super-regexp font-lock-variable-name-face)))
   "Wren keywords highlighting.")

--- a/wren-mode.el
+++ b/wren-mode.el
@@ -58,13 +58,13 @@
   :group 'wren
   :safe 'integerp)
 
-(defvar wren-this-regexp "_\\w+")
+(defvar wren-this-regexp "\\_<_\\(\\w\\|\\s_\\)+\\_>")
 ;; (defvar wren-defun-regexp "\\w+\\( \\|\t\\){")
 
 
 (defvar wren-font-lock-keywords
-  `((,(regexp-opt wren-keywords 'words) . font-lock-keyword-face)
-    (,(regexp-opt wren-constants 'words) . font-lock-constant-face)
+  `((,(regexp-opt wren-keywords 'symbols) . font-lock-keyword-face)
+    (,(regexp-opt wren-constants 'symbols) . font-lock-constant-face)
     (,wren-this-regexp . font-lock-variable-name-face))
   "Wren keywords highlighting.")
 

--- a/wren-mode.el
+++ b/wren-mode.el
@@ -181,6 +181,7 @@
   (modify-syntax-entry ?< "." wren-mode-syntax-table)
   (modify-syntax-entry ?= "." wren-mode-syntax-table)
   (modify-syntax-entry ?~ "." wren-mode-syntax-table)
+  (modify-syntax-entry ?_ "_" wren-mode-syntax-table)
 
   (setq font-lock-defaults '((wren-font-lock-keywords)))
 

--- a/wren-mode.el
+++ b/wren-mode.el
@@ -170,6 +170,7 @@
   (modify-syntax-entry ?/ ". 124b" wren-mode-syntax-table)
   (modify-syntax-entry ?* ". 23n" wren-mode-syntax-table)
   (modify-syntax-entry ?\n "> b" wren-mode-syntax-table)
+  (modify-syntax-entry ?\\ "\\" wren-mode-syntax-table)
   (modify-syntax-entry ?+ "." wren-mode-syntax-table)
   (modify-syntax-entry ?^ "." wren-mode-syntax-table)
   (modify-syntax-entry ?% "." wren-mode-syntax-table)

--- a/wren-mode.el
+++ b/wren-mode.el
@@ -42,15 +42,15 @@
 
 (defconst wren-keywords:data
   '("class" "var" "new")
-  "wren keywords for data")
+  "Wren keywords for data.")
 
 (defconst wren-keywords:control-flow
   '("if" "else" "while" "for" "return")
-  "wren keywords for control flow")
+  "Wren keywords for control flow.")
 
 (defconst wren-keywords:op:logic
   '("and" "or" "not" "is")
-  "wren keywords for control flow")
+  "Wren keywords for control flow.")
 
 (defcustom wren-tab-width tab-width
   "The tab width to use when indenting."
@@ -75,11 +75,11 @@
            font-lock-keyword-face)
      (cons wren-this-regexp font-lock-variable-name-face)
      (cons wren-super-regexp font-lock-variable-name-face)))
-  "wren keywords highlighting")
+  "Wren keywords highlighting.")
 
 
 (defun wren-comment-or-string-p (&optional pos)
-  "Returns true if the point is in a comment or string."
+  "Return t if it's a comment or string at POS, defaulting to point."
   (save-excursion (let ((parse-result (syntax-ppss pos)))
                     (or (elt parse-result 3) (elt parse-result 4)))))
 
@@ -92,12 +92,14 @@
 
 
 (defun wren-goto-preivous-nonblank-line ()
+  "Move backward until on a non blank line."
   (forward-line -1)
   (while (and (looking-at "^[ \t]*$") (not (bobp)))
     (forward-line -1)))
 
 
 (defun wren-indent-to (x)
+  "Indent line to X column."
   (when x
     (let (shift top beg)
       (and (< x 0) (error "invalid nest"))
@@ -121,6 +123,7 @@
 
 ;;;###autoload
 (defun wren-calculate-indent ()
+  "Return the column to which the current line should be indented."
   (interactive)
 
   (let* ((pos (point))
@@ -158,6 +161,7 @@
 
 ;;;###autoload
 (defun wren-indent-line ()
+  "Indent current line of Wren code."
   (interactive)
   (wren-indent-to (wren-calculate-indent)))
 

--- a/wren-mode.el
+++ b/wren-mode.el
@@ -174,7 +174,6 @@
   (modify-syntax-entry ?/ ". 124b" wren-mode-syntax-table)
   (modify-syntax-entry ?* ". 23" wren-mode-syntax-table)
   (modify-syntax-entry ?\n "> b" wren-mode-syntax-table)
-  (modify-syntax-entry ?' "\"" wren-mode-syntax-table)
   (modify-syntax-entry ?+ "." wren-mode-syntax-table)
   (modify-syntax-entry ?^ "." wren-mode-syntax-table)
   (modify-syntax-entry ?% "." wren-mode-syntax-table)

--- a/wren-mode.el
+++ b/wren-mode.el
@@ -183,6 +183,8 @@
 
   (setq font-lock-defaults '((wren-font-lock-keywords)))
 
+  (set (make-local-variable 'electric-indent-chars) '(?\n ?\}))
+
   (set (make-local-variable 'comment-start) "//")
 
   (set (make-local-variable 'indent-line-function) 'wren-indent-line))

--- a/wren-mode.el
+++ b/wren-mode.el
@@ -1,3 +1,45 @@
+;;; wren-mode.el --- Major mode for editing Wren scripts
+;;
+;; Version: 0.0.0
+;; Keywords: languages, wren
+;; URL: https://github.com/v2e4lisp/wren-mode.el
+;; Package-Requires: ((emacs "24.3"))
+;;
+;; This file is not part of Emacs.
+;;
+;; This is free and unencumbered software released into the public domain.
+;;
+;; Anyone is free to copy, modify, publish, use, compile, sell, or
+;; distribute this software, either in source code form or as a compiled
+;; binary, for any purpose, commercial or non-commercial, and by any
+;; means.
+;;
+;; In jurisdictions that recognize copyright laws, the author or authors
+;; of this software dedicate any and all copyright interest in the
+;; software to the public domain. We make this dedication for the benefit
+;; of the public at large and to the detriment of our heirs and
+;; successors. We intend this dedication to be an overt act of
+;; relinquishment in perpetuity of all present and future rights to this
+;; software under copyright law.
+;;
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+;; IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+;; OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+;; ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+;; OTHER DEALINGS IN THE SOFTWARE.
+;;
+;; For more information, please refer to <http://unlicense.org>
+;;
+;;; Commentary:
+;;
+;; Provides support for editing Wren, providing indentation
+;; and syntactical font-locking.
+;;
+;;; Code:
+
+
 (defconst wren-keywords:data
   '("class" "var" "new")
   "wren keywords for data")
@@ -147,3 +189,4 @@
 (add-to-list 'auto-mode-alist '("\\.wren\\'" . wren-mode))
 
 (provide 'wren-mode)
+;;; wren-mode.el ends here

--- a/wren-mode.el
+++ b/wren-mode.el
@@ -169,8 +169,8 @@
   "Major mode for editing Wren."
 
   ;; syntax table
-  (modify-syntax-entry ?/ ". 124bn" wren-mode-syntax-table)
-  (modify-syntax-entry ?* ". 23bn" wren-mode-syntax-table)
+  (modify-syntax-entry ?/ ". 124b" wren-mode-syntax-table)
+  (modify-syntax-entry ?* ". 23n" wren-mode-syntax-table)
   (modify-syntax-entry ?\n "> b" wren-mode-syntax-table)
   (modify-syntax-entry ?+ "." wren-mode-syntax-table)
   (modify-syntax-entry ?^ "." wren-mode-syntax-table)

--- a/wren-mode.el
+++ b/wren-mode.el
@@ -63,14 +63,9 @@
 
 
 (defvar wren-font-lock-keywords
-  (let ((beg "\\<")
-        (end "\\>"))
-    (list
-     (cons (concat beg (regexp-opt wren-keywords t) end)
-           font-lock-keyword-face)
-     (cons (concat beg (regexp-opt wren-constants t) end)
-           font-lock-constant-face)
-     (cons wren-this-regexp font-lock-variable-name-face)))
+  `((,(regexp-opt wren-keywords 'words) . font-lock-keyword-face)
+    (,(regexp-opt wren-constants 'words) . font-lock-constant-face)
+    (,wren-this-regexp . font-lock-variable-name-face))
   "Wren keywords highlighting.")
 
 

--- a/wren-mode.el
+++ b/wren-mode.el
@@ -59,7 +59,6 @@
   :safe 'integerp)
 
 (defvar wren-this-regexp "_\\w+")
-(defvar wren-super-regexp "\\<super\\>")
 ;; (defvar wren-defun-regexp "\\w+\\( \\|\t\\){")
 
 
@@ -71,8 +70,7 @@
            font-lock-keyword-face)
      (cons (concat beg (regexp-opt wren-constants t) end)
            font-lock-constant-face)
-     (cons wren-this-regexp font-lock-variable-name-face)
-     (cons wren-super-regexp font-lock-variable-name-face)))
+     (cons wren-this-regexp font-lock-variable-name-face)))
   "Wren keywords highlighting.")
 
 

--- a/wren-mode.el
+++ b/wren-mode.el
@@ -100,7 +100,7 @@
   "Indent line to X column."
   (when x
     (let (shift top beg)
-      (and (< x 0) (error "invalid nest"))
+      (and (< x 0) (error "Invalid nest"))
       (setq shift (current-column))
       (beginning-of-line)
       (setq beg (point))
@@ -165,7 +165,7 @@
 
 
 ;;;###autoload
-(define-derived-mode wren-mode prog-mode "wren"
+(define-derived-mode wren-mode prog-mode "Wren"
   "Major mode for editing Wren."
 
   ;; syntax table


### PR DESCRIPTION
Hello,

I've made a lot of little changes, I've tried to break them down in small individual commits to make it easier for you to review. 

There was also things I haven't changed but wanted to discuss:
1. I'm having trouble with `wren-tab-width` because it's conflicting with EditorConfig. wren-tab-width get set to the default tab-width which is eight, then EditorConfig sets tab-width to two (what I want) but it's too late, wren-tab-width got already wrongly set to the default. If I remove wren-tab-width and use tab-width in the code, everything works well.
2. Not sure why `wren-indent-line` and `wren-calculate-indent` have ###autoload, is that okay ?
3. I noticed c-mode is also adding `?-`, `?&` and `?|` to punctuation and `?\\` to escape to it's syntax table. Otherwise it's pretty much the same, not sure if it would be relevant to also add them.

Anyway, I hope this PR make sense to you, please ask if you have any questions.
Thanks for publishing this, I had fun playing around with it :-)
